### PR TITLE
Fix mobile landscape

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -2490,7 +2490,7 @@ margin-bottom: -5px;
 }
 
 .layout-mobile .mainDrawer {
-	width: 65% !important;
+	width: 320px !important;
 }
 
 

--- a/theme.css
+++ b/theme.css
@@ -2490,7 +2490,7 @@ margin-bottom: -5px;
 }
 
 .layout-mobile .mainDrawer {
-	width: 320px !important;
+	width: 315px !important;
 }
 
 


### PR DESCRIPTION
Very nice theme!

On mobile when having it in landscape, it won't show the menu buttons.
To test go in Chrome into the responsive mode -> Select Iphone 12 Pro -> Rotate it to landscape

However I found the problem, you are specifying the menubar in relative-percent (Im not really sure why you specified it this way). But this way the menu is too wide on such screens and the translate when opening up the menu is not enough any more to fully show it. My change fixes that

<img width="400" alt="image" src="https://github.com/stpnwf/ZestyTheme/assets/671752/b99e115e-0a1f-4a70-83f0-8db37f083b77">

(I cut the picture for privacy, but the tablet was in landscape)
