### PR TITLE
fix: show main image in actor and season detailed pages

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -4035,6 +4035,13 @@
   width: 90vw;
 }
 
+/*
+ * Set a min-height (same height to be in line with bottom of poster) for season
+ * overview's episode list to guarantee poster will not overlap cast/crew section.
+ */
+#itemDetailPage:has(.portraitCard .material-icons.folder) #childrenContent {
+	min-height: clamp(15vw * .75, 33.33svh * .75, 20vw * .75);
+}
 /* Progressive enhancement: when there are 3 or more episodes, use sticky positioned season poster */
 #itemDetailPage:has(.childrenItemsContainer > :nth-child(3))
 .detailImageContainer:has(.portraitCard .material-icons.folder) {
@@ -4049,9 +4056,9 @@
     .material-icons.folder
   )
 ) {
-  width: clamp(15vw, 33.33dvh, 20vw);
+  width: clamp(15vw, 33.33svh, 20vw);
   right: 0;
-  top: 50dvh;
+  top: 50svh;
   bottom: auto;
   margin: auto;
   transform: translateY(-50%);
@@ -4064,9 +4071,5 @@
   /* Season overview poster */
   #itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.folder) {
     left: 57.5vw;
-    top: max(50dvh, 380px);
-  }
-  #itemDetailPage:has(.childrenItemsContainer > :last-child:nth-child(-n + 2))
-  .detailImageContainer > .portraitCard:has(.material-icons.folder) {
-    top: max(35dvh, 340px);
+    top: max(50svh, 380px);
   }

--- a/theme.css
+++ b/theme.css
@@ -4014,36 +4014,40 @@
  *
  * Targets pages to unset the display: none that may have been applied
  * over-zealously.
- *
- * Notes:
- *  - "#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide)"
- *    is the actor page, it's the only (needs checking) detail page
- *    that has a hidden play button.
- *  - "#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)"
- *    is the season overview page, it's the only (needs checking) detail
- *    page where the header has a h3.itemName:not(.focuscontainer-x) element
 **/
-#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
-#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .cardBox,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .cardBox {
+
+/* Actor/actress page */
+#itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.person),
+#itemDetailPage .detailImageContainer > .portraitCard > .cardBox:has(.material-icons.person),
+/* Season overview */
+#itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.folder),
+#itemDetailPage .detailImageContainer > .portraitCard > .cardBox:has(.material-icons.folder) {
   display: block;
 }
 
-#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide),
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) {
+#itemDetailPage .detailPagePrimaryContainer:has(
+  .detailImageContainer .portraitCard :where(
+    .material-icons.person,
+    .material-icons.folder
+  )
+) {
   width: 90%;
 }
 
-/* Progressive enhancement: when there are 3 or more episodes, use sticky positioned poster */
+/* Progressive enhancement: when there are 3 or more episodes, use sticky positioned season poster */
 #itemDetailPage:has(.childrenItemsContainer > :nth-child(3))
-.detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .detailImageContainer {
+.detailImageContainer:has(.portraitCard .material-icons.folder) {
   position: sticky;
   top: 0;
 }
 
-#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card {
+/* Main portrait poster/photo */
+#itemDetailPage .detailImageContainer > .portraitCard:has(
+  :where(
+    .material-icons.person,
+    .material-icons.folder
+  )
+) {
   width: 20vw;
   right: 0;
   top: 50dvh;
@@ -4051,11 +4055,13 @@
   margin: auto;
   transform: translateY(-50%);
 }
-  #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card {
+  /* Actor/actress page photo */
+  #itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.person) {
     left: 57.5vw;
     position: fixed !important;
   }
-  #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card {
+  /* Season overview poster */
+  #itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.folder) {
     left: 57.5vw;
     top: max(50dvh, 380px);
   }

--- a/theme.css
+++ b/theme.css
@@ -4004,18 +4004,23 @@
   width: 90%;
 }
 
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .detailImageContainer {
+  position: sticky;
+  top: 0;
+}
+
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
 #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card {
   width: 20vw;
-  position: absolute;
   right: 0;
-  top: max(39vh, 120%);
+  top: 50dvh;
   bottom: auto;
   margin: auto;
   transform: translateY(-50%);
 }
   #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card {
-    left: 50vw;
+    left: 57.5vw;
+    position: fixed !important;
   }
   #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card {
     left: 57.5vw;

--- a/theme.css
+++ b/theme.css
@@ -3976,3 +3976,42 @@
   font-size: 1.75em;
   font-weight: 600;
 }
+
+
+/*
+ * Fix: Detailed page image missing for actor and season overview pages.
+ *
+ * Targets pages to unset the display: none that may have been applied
+ * over-zealously.
+ *
+ * Notes:
+ *  - "#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide)"
+ *    is the actor page, it's the only (needs checking) detail page
+ *    that has a hidden play button.
+ *  - "#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3)"
+ *    is the season overview page, it's the only (needs checking) detail
+ *    page where the header has a H3 element
+**/
+#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
+#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .cardBox,
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .card,
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .cardBox {
+  display: block;
+}
+
+#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide),
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) {
+  width: 90%;
+}
+
+#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .card {
+  width: 20vw;
+  position: absolute;
+  left: 50vw;
+  right: 0;
+  top: max(39vh, 120%);
+  bottom: auto;
+  margin: auto;
+  transform: translateY(-50%);
+}

--- a/theme.css
+++ b/theme.css
@@ -3988,24 +3988,24 @@
  *  - "#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide)"
  *    is the actor page, it's the only (needs checking) detail page
  *    that has a hidden play button.
- *  - "#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3)"
+ *  - "#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName)"
  *    is the season overview page, it's the only (needs checking) detail
- *    page where the header has a H3 element
+ *    page where the header has a h3.itemName element
 **/
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .cardBox,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .card,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .cardBox {
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) .card,
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) .cardBox {
   display: block;
 }
 
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide),
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) {
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) {
   width: 90%;
 }
 
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .card {
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) .card {
   width: 20vw;
   position: absolute;
   right: 0;

--- a/theme.css
+++ b/theme.css
@@ -1910,7 +1910,38 @@
     }
   }
 
-
+  /* Zen browser fix */
+  @media (min-width: 87.5em) and (max-width: 105em) {
+	  .layout-desktop .listItemImage.listItemImage-large.itemAction.lazy {
+		  height: 127px;
+		  width: 227px;
+	  }
+	  .layout-desktop.secondary.listItem-overview.listItemBodyText {
+		  height: 5.5em;
+		  margin: 0;
+	  }
+  }
+  @media (min-width: 45.5em) and (max-width: 87.4999em) {
+	  .layout-desktop .listItemImage.listItemImage-large.itemAction.lazy {
+		  height: 120px;
+		  width: 190px;
+	  }
+	  .layout-desktop .listItem-content {
+		  height: 130px;
+	  }
+	  .layout-desktop .listItem-content .listItemBody {
+		  height: 8em;
+	  }
+  }
+  /* Fix for logos on 2K screens */
+  @media (min-width: 130em) {
+    .layout-desktop .detailPageWrapperContainer {
+        margin-top: -84vh;
+    }
+    .layout-desktop .detailLogo {
+        width: 36em;
+    }
+  }
   /* #### login frame #### */
 
 

--- a/theme.css
+++ b/theme.css
@@ -3988,24 +3988,24 @@
  *  - "#itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide)"
  *    is the actor page, it's the only (needs checking) detail page
  *    that has a hidden play button.
- *  - "#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName)"
+ *  - "#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)"
  *    is the season overview page, it's the only (needs checking) detail
- *    page where the header has a h3.itemName element
+ *    page where the header has a h3.itemName:not(.focuscontainer-x) element
 **/
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .cardBox,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) .card,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) .cardBox {
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card,
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .cardBox {
   display: block;
 }
 
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide),
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) {
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) {
   width: 90%;
 }
 
 #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card,
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName) .card {
+#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card {
   width: 20vw;
   position: absolute;
   right: 0;
@@ -4017,6 +4017,6 @@
   #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card {
     left: 50vw;
   }
-  #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .card {
+  #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card {
     left: 57.5vw;
   }

--- a/theme.css
+++ b/theme.css
@@ -4015,14 +4015,15 @@
  * Targets pages to unset the display: none that may have been applied
  * over-zealously.
 **/
-
-/* Actor/actress page */
-#itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.person),
-#itemDetailPage .detailImageContainer > .portraitCard > .cardBox:has(.material-icons.person),
-/* Season overview */
-#itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.folder),
-#itemDetailPage .detailImageContainer > .portraitCard > .cardBox:has(.material-icons.folder) {
-  display: block;
+@media (min-width: 820px) {
+  /* Actor/actress page */
+  #itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.person),
+  #itemDetailPage .detailImageContainer > .portraitCard > .cardBox:has(.material-icons.person),
+  /* Season overview */
+  #itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.folder),
+  #itemDetailPage .detailImageContainer > .portraitCard > .cardBox:has(.material-icons.folder) {
+    display: block;
+  }
 }
 
 #itemDetailPage .detailPagePrimaryContainer:has(
@@ -4031,7 +4032,7 @@
     .material-icons.folder
   )
 ) {
-  width: 90%;
+  width: 90vw;
 }
 
 /* Progressive enhancement: when there are 3 or more episodes, use sticky positioned season poster */
@@ -4048,7 +4049,7 @@
     .material-icons.folder
   )
 ) {
-  width: 20vw;
+  width: clamp(15vw, 33.33dvh, 20vw);
   right: 0;
   top: 50dvh;
   bottom: auto;
@@ -4064,4 +4065,8 @@
   #itemDetailPage .detailImageContainer > .portraitCard:has(.material-icons.folder) {
     left: 57.5vw;
     top: max(50dvh, 380px);
+  }
+  #itemDetailPage:has(.childrenItemsContainer > :last-child:nth-child(-n + 2))
+  .detailImageContainer > .portraitCard:has(.material-icons.folder) {
+    top: max(35dvh, 340px);
   }

--- a/theme.css
+++ b/theme.css
@@ -4035,7 +4035,9 @@
   width: 90%;
 }
 
-#itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .detailImageContainer {
+/* Progressive enhancement: when there are 3 or more episodes, use sticky positioned poster */
+#itemDetailPage:has(.childrenItemsContainer > :nth-child(3))
+.detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .detailImageContainer {
   position: sticky;
   top: 0;
 }
@@ -4055,4 +4057,5 @@
   }
   #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3.itemName:not(.focuscontainer-x)) .card {
     left: 57.5vw;
+    top: max(50dvh, 380px);
   }

--- a/theme.css
+++ b/theme.css
@@ -4008,10 +4008,15 @@
 #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .card {
   width: 20vw;
   position: absolute;
-  left: 50vw;
   right: 0;
   top: max(39vh, 120%);
   bottom: auto;
   margin: auto;
   transform: translateY(-50%);
 }
+  #itemDetailPage .detailPagePrimaryContainer:has(.btnPlay.hide) .card {
+    left: 50vw;
+  }
+  #itemDetailPage .detailPagePrimaryContainer:has(.nameContainer > h3) .card {
+    left: 57.5vw;
+  }


### PR DESCRIPTION
Work in progress.

- Movie page — poster not shown (because I assume this is a design choice)
- Actor's profile — their photograph is shown
- Movie collection overview — no picture shown (looks to be a design choice)
- TV show initial overview — poster not shown (again, looks deliberate)
- TV show's season overview — poster is shown
- Music album — will need to check this when I have content loaded for this
- Music artist profile — will need to check this when I have content loaded for this

Just need to check that their are no design regressions for the music/audiobook/book side of things, and I would like to check that the image in the layout will be responsive as well.