### PR TITLE
Limited the number of displayed posters in Genres tab to fit in one row

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -3200,6 +3200,13 @@
 	  background-position: 70%;
   }
 
+  /* Limits the number of displayed posters in Genres tab to fit in one row */
+  @media (max-width: 43.75em) { #genresTab .card:nth-child(n+4) { display: none } }
+  @media (max-width: 50em) { #genresTab .card:nth-child(n+5) { display: none } }
+  @media (max-width: 75em) { #genresTab .card:nth-child(n+6) { display: none } }
+  @media (max-width: 87.5em) { #genresTab .card:nth-child(n+7) { display: none } }
+  @media (min-width: 87.5em) { #genresTab .card:nth-child(n+8) { display: none } }
+
 
   /* --- ### PLUGINS ### --- */
 
@@ -4007,4 +4014,3 @@
   font-size: 1.75em;
   font-weight: 600;
 }
-


### PR DESCRIPTION
- Used values from "Makes posters larger in the Library view and Home screen" block to hide elements out of default 9, that do not fit in one row